### PR TITLE
Fixed license for ttf2bmp.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ Source FLOSS compatible Han bitmap font file and add support for it.
 * [水城珠洲](http://minashiro.net/) for their [FreeDOS/V project and DOS/V font file](http://dos.minashiro.net/)
 
 # License notice
-* ttf2bmp.py - BSD 3-clause https://github.com/sukso96100/amazfit-bip-kr
+* ttf2bmp.py - MIT License https://github.com/sukso96100/amazfit-bip-kr
 * Bm437_IBM_PS2thin4.FON - CC-BY-SA 4.0 https://int10h.org/oldschool-pc-fonts/
 * 04GZN16X.FNT - GNU GPL v2 http://dos.minashiro.net/freedosvd.html


### PR DESCRIPTION
Fixed license information for the file ttf2bmp.py

안녕하세요. 제가 간단히 작성한 스크립트를 멋진 도구 만드시는데 활용해 주셔서 감사합니다.
ttf2bmp.py 의 라이선스는 BSD-3-Clause 가 아닌 MIT License 입니다.
라이선스 부분 정보가 잘못되어 있어 이를 수정하는 PR 을 제출합니다.